### PR TITLE
fix(codex): normalize legacy replay tool IDs

### DIFF
--- a/pi/agent/extensions/apply-patch/freeform-codex.ts
+++ b/pi/agent/extensions/apply-patch/freeform-codex.ts
@@ -418,7 +418,15 @@ function buildRequestBody(
 	return body;
 }
 
-function convertFreeformResponsesMessages(model: Model<any>, context: Context, toolName: string) {
+function normalizeCustomToolCallItemId(id: string | undefined): string | undefined {
+	if (!id) return undefined;
+	const withoutFunctionPrefix = id.startsWith("fc_ctc_") ? id.slice("fc_".length) : id;
+	const sanitized = withoutFunctionPrefix.replace(/[^a-zA-Z0-9_-]/g, "_");
+	const normalized = (sanitized.startsWith("ctc_") ? sanitized : `ctc_${sanitized}`).replace(/_+$/, "");
+	return normalized.length > 64 ? normalized.slice(0, 64) : normalized;
+}
+
+export function convertFreeformResponsesMessages(model: Model<any>, context: Context, toolName: string) {
 	const messages = convertResponsesMessages(model, context, CODEX_TOOL_CALL_PROVIDERS, { includeSystemPrompt: false });
 	const applyPatchCallIds = new Set<string>();
 	return messages.map((item: any) => {
@@ -430,7 +438,7 @@ function convertFreeformResponsesMessages(model: Model<any>, context: Context, t
 			} catch {}
 			return {
 				type: "custom_tool_call",
-				id: item.id,
+				id: normalizeCustomToolCallItemId(item.id),
 				call_id: item.call_id,
 				name: item.name,
 				input,

--- a/pi/agent/extensions/apply-patch/index.test.ts
+++ b/pi/agent/extensions/apply-patch/index.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	closeOpenAICodexWebSocketSessions,
+	convertFreeformResponsesMessages,
 	convertTools,
 	getOpenAICodexWebSocketDebugStats,
 	mapFreeformEvents,
@@ -651,6 +652,45 @@ async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
 }
 
 describe("apply_patch Codex freeform provider", () => {
+	it("replays legacy apply_patch calls as Codex custom tool calls with ctc ids", () => {
+		const messages = convertFreeformResponsesMessages(
+			{
+				id: "gpt-5.5",
+				provider: "openai-codex",
+				api: "openai-codex-responses",
+				input: ["text"],
+			} as any,
+			{
+				messages: [
+					{
+						role: "assistant",
+						api: "openai-codex-responses",
+						provider: "openai-codex",
+						model: "gpt-5.5",
+						content: [
+							{
+								type: "toolCall",
+								id: "call_apply_patch|ctc_0ae3fabeb0423f2e016a00c39c449c81919eab6c5ebf693f2e",
+								name: "apply_patch",
+								arguments: { input: "*** Begin Patch\n*** End Patch" },
+							},
+						],
+						stopReason: "toolUse",
+						timestamp: 1,
+					},
+				],
+				systemPrompt: "",
+				tools: [],
+			} as any,
+			"apply_patch",
+		) as any[];
+
+		const call = messages.find((item) => item.type === "custom_tool_call");
+		expect(call.id.startsWith("ctc_")).toBe(true);
+		expect(call.id.startsWith("fc_")).toBe(false);
+		expect(call.call_id).toBe("call_apply_patch");
+	});
+
 	it("converts only apply_patch custom tool stream events", async () => {
 		const events = [
 			{

--- a/pi/agent/extensions/codex-native/compaction/src/serializer.ts
+++ b/pi/agent/extensions/codex-native/compaction/src/serializer.ts
@@ -119,6 +119,18 @@ function sanitizeSurrogates(text: string): string {
 	return text.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "");
 }
 
+function normalizeIdPart(part: string): string {
+	const sanitized = part.replace(/[^a-zA-Z0-9_-]/g, "_");
+	const normalized = sanitized.length > 64 ? sanitized.slice(0, 64) : sanitized;
+	return normalized.replace(/_+$/, "");
+}
+
+function normalizeResponsesFunctionCallItemId(itemId: string | undefined): string | undefined {
+	if (!itemId) return undefined;
+	const normalizedItemId = normalizeIdPart(itemId);
+	return normalizedItemId.startsWith("fc_") ? normalizedItemId : normalizeIdPart(`fc_${normalizedItemId}`);
+}
+
 export function collectCompactionWindowMessages(preparation: CompactionPreparation): AgentMessage[] {
 	return [...preparation.messagesToSummarize, ...preparation.turnPrefixMessages];
 }
@@ -402,7 +414,7 @@ function serializeAssistantMessage(message: AssistantMessage, messageIndex: numb
 			const [callId, rawItemId] = block.id.split("|");
 			items.push({
 				type: "function_call",
-				id: rawItemId,
+				id: normalizeResponsesFunctionCallItemId(rawItemId),
 				call_id: callId,
 				name: block.name,
 				arguments: JSON.stringify(block.arguments),

--- a/pi/agent/extensions/codex-native/compaction/src/unit.test.ts
+++ b/pi/agent/extensions/codex-native/compaction/src/unit.test.ts
@@ -170,6 +170,37 @@ test("serializer sanitizes unpaired surrogates in instructions and message conte
 	expect(JSON.stringify(inputOnly)).not.toContain("\\udc00");
 });
 
+test("serializer normalizes legacy custom tool call item ids for function-call replay", async () => {
+	const { serializeMessagesToResponsesInput } = await loadSerializerModule();
+	const input = serializeMessagesToResponsesInput(
+		baseModel as never,
+		[
+			{
+				role: "assistant",
+				provider: baseModel.provider,
+				api: baseModel.api,
+				model: baseModel.id,
+				stopReason: "toolUse",
+				content: [
+					{
+						type: "toolCall",
+						id: "call_apply_patch|ctc_0ae3fabeb0423f2e016a00c39c449c81919eab6c5ebf693f2e",
+						name: "apply_patch",
+						arguments: { input: "*** Begin Patch\n*** End Patch" },
+					},
+				],
+				timestamp: 1,
+			},
+		] as never,
+	);
+
+	const call = input.find((item) => item.type === "function_call") as { id: string; call_id: string };
+	expect(call.id.startsWith("fc_")).toBe(true);
+	expect(call.id.startsWith("ctc_")).toBe(false);
+	expect(call.id.length).toBeLessThanOrEqual(64);
+	expect(call.call_id).toBe("call_apply_patch");
+});
+
 test("serializer preserves assistant image generation call blocks", async () => {
 	const { serializeMessagesToResponsesInput } = await loadSerializerModule();
 	const input = serializeMessagesToResponsesInput(

--- a/pi/agent/extensions/codex-native/index.test.ts
+++ b/pi/agent/extensions/codex-native/index.test.ts
@@ -3,7 +3,11 @@ import { mkdir, mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { activeCodexAppsToolNames, discoverCodexAppsTools } from "./codex-apps.ts";
-import { isCodexWebSocketError, normalizeCodexWebSocketError as normalizeCodexWebSocketErrorMessage } from "./index.ts";
+import {
+	isCodexWebSocketError,
+	normalizeCodexWebSocketError as normalizeCodexWebSocketErrorMessage,
+	normalizeLegacyFunctionCallIds,
+} from "./index.ts";
 import {
 	createWebSearchTool,
 	getOpenAICodexLatestImagePath,
@@ -14,6 +18,7 @@ import {
 	supportsNativeWebSearch,
 	WEB_SEARCH_TOOL_NAME,
 } from "./native-tools.ts";
+import { convertResponsesMessages } from "./openai-responses-shared.ts";
 
 const codexModel = {
 	provider: "openai-codex",
@@ -25,6 +30,72 @@ const testTheme = {
 	fg: (role: string, text: string) => `<${role}>${text}</${role}>`,
 	bold: (text: string) => `<bold>${text}</bold>`,
 };
+
+test("normalizes legacy function call item ids at the provider-request boundary", () => {
+	const payload = {
+		input: [
+			{ type: "function_call", id: "ctc_0ae3fabeb0423f2e016a00c39c449c81919eab6c5ebf693f2e", call_id: "call_1" },
+			{ type: "function_call", id: "fc_valid", call_id: "call_2" },
+			{
+				type: "custom_tool_call",
+				id: "fc_ctc_0ae3fabeb0423f2e016a00c39c449c81919eab6c5ebf693f2e",
+				call_id: "call_3",
+			},
+			{ type: "custom_tool_call", id: "ctc_custom", call_id: "call_4" },
+		],
+	};
+
+	const rewritten = normalizeLegacyFunctionCallIds(payload) as typeof payload;
+	expect(rewritten.input[0]?.id.startsWith("fc_")).toBe(true);
+	expect(rewritten.input[0]?.id.startsWith("ctc_")).toBe(false);
+	expect(rewritten.input[1]?.id).toBe("fc_valid");
+	expect(rewritten.input[2]?.id.startsWith("ctc_")).toBe(true);
+	expect(rewritten.input[2]?.id.startsWith("fc_")).toBe(false);
+	expect(rewritten.input[3]?.id).toBe("ctc_custom");
+});
+
+test("normalizes legacy Codex custom tool call item ids for Responses replay", () => {
+	const messages = convertResponsesMessages(
+		{ ...codexModel, api: "openai-codex-responses" } as never,
+		{
+			messages: [
+				{
+					role: "assistant",
+					api: "openai-codex-responses",
+					provider: "openai-codex",
+					model: "gpt-5.5",
+					content: [
+						{
+							type: "toolCall",
+							id: "call_apply_patch|ctc_0ae3fabeb0423f2e016a00c39c449c81919eab6c5ebf693f2e",
+							name: "apply_patch",
+							arguments: { input: "*** Begin Patch\n*** End Patch" },
+						},
+					],
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				{
+					role: "toolResult",
+					toolCallId: "call_apply_patch|ctc_0ae3fabeb0423f2e016a00c39c449c81919eab6c5ebf693f2e",
+					toolName: "apply_patch",
+					content: [{ type: "text", text: "ok" }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+			],
+			systemPrompt: "",
+			tools: [],
+		} as never,
+		new Set(["openai-codex"]),
+	) as any[];
+
+	const call = messages.find((item) => item.type === "function_call");
+	expect(call.id.startsWith("fc_")).toBe(true);
+	expect(call.id.startsWith("ctc_")).toBe(false);
+	expect(call.call_id).toBe("call_apply_patch");
+	expect(call.id.length).toBeLessThanOrEqual(64);
+});
 
 test("rewrites Codex web_search function tool to native Responses tool", () => {
 	const payload = {

--- a/pi/agent/extensions/codex-native/index.ts
+++ b/pi/agent/extensions/codex-native/index.ts
@@ -24,6 +24,46 @@ function arraysEqual(a: string[], b: string[]): boolean {
 	return a.length === b.length && a.every((value, index) => value === b[index]);
 }
 
+function normalizeResponsesIdPart(part: string): string {
+	const sanitized = part.replace(/[^a-zA-Z0-9_-]/g, "_");
+	const normalized = sanitized.length > 64 ? sanitized.slice(0, 64) : sanitized;
+	return normalized.replace(/_+$/, "");
+}
+
+function normalizeFunctionCallItemId(id: string): string {
+	const normalized = normalizeResponsesIdPart(id);
+	return normalized.startsWith("fc_") ? normalized : normalizeResponsesIdPart(`fc_${normalized}`);
+}
+
+function normalizeCustomToolCallItemId(id: string): string {
+	const withoutFunctionPrefix = id.startsWith("fc_ctc_") ? id.slice("fc_".length) : id;
+	const normalized = normalizeResponsesIdPart(withoutFunctionPrefix);
+	return normalized.startsWith("ctc_") ? normalized : normalizeResponsesIdPart(`ctc_${normalized}`);
+}
+
+export function normalizeLegacyFunctionCallIds(payload: unknown): unknown {
+	if (!payload || typeof payload !== "object") return payload;
+	const input = (payload as { input?: unknown }).input;
+	if (!Array.isArray(input)) return payload;
+
+	let changed = false;
+	const nextInput = input.map((item) => {
+		if (!item || typeof item !== "object" || Array.isArray(item)) return item;
+		const record = item as { type?: unknown; id?: unknown };
+		if (record.type === "function_call" && typeof record.id === "string" && !record.id.startsWith("fc_")) {
+			changed = true;
+			return { ...record, id: normalizeFunctionCallItemId(record.id) };
+		}
+		if (record.type === "custom_tool_call" && typeof record.id === "string" && !record.id.startsWith("ctc_")) {
+			changed = true;
+			return { ...record, id: normalizeCustomToolCallItemId(record.id) };
+		}
+		return item;
+	});
+
+	return changed ? { ...(payload as object), input: nextInput } : payload;
+}
+
 export function normalizeCodexWebSocketError(message: AssistantMessage): AssistantMessage | undefined {
 	if (message.provider !== "openai-codex") return undefined;
 	if (message.stopReason !== "error") return undefined;
@@ -102,6 +142,8 @@ export default async function codexNativeExtension(pi: ExtensionAPI) {
 	});
 
 	pi.on("before_provider_request", async (event, ctx) =>
-		rewriteNativeImageGenerationTool(rewriteNativeWebSearchTool(event.payload, ctx.model), ctx.model),
+		normalizeLegacyFunctionCallIds(
+			rewriteNativeImageGenerationTool(rewriteNativeWebSearchTool(event.payload, ctx.model), ctx.model),
+		),
 	);
 }

--- a/pi/agent/extensions/codex-native/openai-responses-shared.ts
+++ b/pi/agent/extensions/codex-native/openai-responses-shared.ts
@@ -302,6 +302,11 @@ export function convertResponsesMessages<TApi extends Api>(
 		const normalized = `fc_${shortHash(itemId)}`;
 		return normalized.length > 64 ? normalized.slice(0, 64) : normalized;
 	};
+	const normalizeResponsesFunctionCallItemId = (itemId: string | undefined) => {
+		if (!itemId) return undefined;
+		const normalizedItemId = normalizeIdPart(itemId);
+		return normalizedItemId.startsWith("fc_") ? normalizedItemId : normalizeIdPart(`fc_${normalizedItemId}`);
+	};
 	const normalizeToolCallId = (
 		id: string,
 		_targetModel: Model<TApi>,
@@ -382,7 +387,7 @@ export function convertResponsesMessages<TApi extends Api>(
 					assistantBlockIndex++;
 				} else if (block.type === "toolCall") {
 					const [callId, itemIdRaw] = block.id.split("|");
-					let itemId: string | undefined = itemIdRaw;
+					let itemId = normalizeResponsesFunctionCallItemId(itemIdRaw);
 					if (isDifferentModel && itemId?.startsWith("fc_")) itemId = undefined;
 					output.push({
 						type: "function_call",


### PR DESCRIPTION
## Summary

Fixes replay of older Codex/apply_patch sessions whose saved Responses item IDs use legacy custom-tool prefixes.

- normalize replayed function-call item IDs to `fc_...`
- normalize replayed custom-tool item IDs to `ctc_...`
- preserve apply_patch freeform replay as Codex `custom_tool_call` items with valid `ctc_...` IDs
- cover normal replay, provider-request boundary replay, and native compaction serialization

## Verification

- `bunx biome check pi/agent/extensions/codex-native/index.ts pi/agent/extensions/codex-native/index.test.ts pi/agent/extensions/apply-patch/freeform-codex.ts pi/agent/extensions/apply-patch/index.test.ts pi/agent/extensions/codex-native/openai-responses-shared.ts pi/agent/extensions/codex-native/compaction/src/serializer.ts pi/agent/extensions/codex-native/compaction/src/unit.test.ts`
- `bun test pi/agent/extensions/apply-patch/index.test.ts pi/agent/extensions/codex-native/index.test.ts pi/agent/extensions/codex-native/compaction/src/unit.test.ts pi/agent/extensions/codex-native/compaction/src/validation.test.ts`
- `bun run typecheck`

Note: `bun run test:codex-native` has an unrelated tty exec-session failure in this temporary worktree; the touched apply_patch/codex-native/compaction tests pass.
