### PR TITLE
feat(mosaic): support agent cwd overrides

### DIFF
--- a/pi/agent/extensions/mosaic/agent-manager.ts
+++ b/pi/agent/extensions/mosaic/agent-manager.ts
@@ -46,6 +46,8 @@ interface SpawnOptions {
 	bypassQueue?: boolean;
 	/** Isolation mode — "worktree" creates a temp git worktree for the agent. */
 	isolation?: IsolationMode;
+	/** Override working directory for the agent. */
+	cwd?: string;
 	/** Parent abort signal — when aborted, the subagent is also stopped. */
 	signal?: AbortSignal;
 	/** Called on tool start/end with activity info (for streaming progress to UI). */
@@ -142,12 +144,13 @@ export class AgentManager {
 
 	/** Actually start an agent (called immediately or from queue drain). */
 	private startAgent(id: string, record: AgentRecord, { pi, ctx, type, prompt, options }: SpawnArgs) {
+		const baseCwd = options.cwd ?? ctx.cwd;
 		// Worktree isolation: try to create a temporary git worktree. Strict —
 		// fail loud if not possible (no silent fallback to main tree). Done
 		// BEFORE state mutation so a throw doesn't leave the record half-running.
 		let worktreeCwd: string | undefined;
 		if (options.isolation === "worktree") {
-			const wt = createWorktree(ctx.cwd, id);
+			const wt = createWorktree(baseCwd, id);
 			if (!wt) {
 				throw new Error(
 					'Cannot run with isolation: "worktree" — not a git repo, no commits yet, or `git worktree add` failed. ' +
@@ -182,7 +185,7 @@ export class AgentManager {
 			isolated: options.isolated,
 			inheritContext: options.inheritContext,
 			thinkingLevel: options.thinkingLevel,
-			cwd: worktreeCwd,
+			cwd: worktreeCwd ?? options.cwd,
 			signal: record.abortController!.signal,
 			onToolActivity: (activity) => {
 				if (activity.type === "end") record.toolUses++;
@@ -234,7 +237,7 @@ export class AgentManager {
 
 				// Clean up worktree if used
 				if (record.worktree) {
-					const wtResult = cleanupWorktree(ctx.cwd, record.worktree, options.description);
+					const wtResult = cleanupWorktree(baseCwd, record.worktree, options.description);
 					record.worktreeResult = wtResult;
 					if (wtResult.hasChanges && wtResult.branch) {
 						record.result =
@@ -277,7 +280,7 @@ export class AgentManager {
 				// Best-effort worktree cleanup on error
 				if (record.worktree) {
 					try {
-						const wtResult = cleanupWorktree(ctx.cwd, record.worktree, options.description);
+						const wtResult = cleanupWorktree(baseCwd, record.worktree, options.description);
 						record.worktreeResult = wtResult;
 					} catch {
 						/* ignore cleanup errors */

--- a/pi/agent/extensions/mosaic/cwd.test.ts
+++ b/pi/agent/extensions/mosaic/cwd.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveAgentCwd } from "./cwd";
+
+describe("resolveAgentCwd", () => {
+	test("resolves relative cwd from the parent cwd", () => {
+		const root = mkdtempSync(join(tmpdir(), "mosaic-cwd-"));
+		const nested = join(root, "repo");
+		mkdirSync(nested);
+
+		expect(resolveAgentCwd("repo", root)).toBe(nested);
+	});
+
+	test("accepts absolute cwd", () => {
+		const root = mkdtempSync(join(tmpdir(), "mosaic-cwd-"));
+		expect(resolveAgentCwd(root, "/irrelevant")).toBe(root);
+	});
+
+	test("rejects files and missing directories", () => {
+		const root = mkdtempSync(join(tmpdir(), "mosaic-cwd-"));
+		const file = join(root, "file.txt");
+		writeFileSync(file, "not a dir");
+
+		expect(() => resolveAgentCwd(file, root)).toThrow("not a directory");
+		expect(() => resolveAgentCwd("missing", root)).toThrow("not a directory");
+	});
+});

--- a/pi/agent/extensions/mosaic/cwd.ts
+++ b/pi/agent/extensions/mosaic/cwd.ts
@@ -1,0 +1,13 @@
+import { existsSync, statSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+export function resolveAgentCwd(input: unknown, baseCwd: string): string | undefined {
+	if (input == null) return undefined;
+	if (typeof input !== "string" || input.trim() === "") throw new Error("`cwd` must be a non-empty string.");
+	const candidate = input.trim();
+	const resolved = isAbsolute(candidate) ? candidate : resolve(baseCwd, candidate);
+	if (!existsSync(resolved) || !statSync(resolved).isDirectory()) {
+		throw new Error(`Agent cwd does not exist or is not a directory: ${resolved}`);
+	}
+	return resolved;
+}

--- a/pi/agent/extensions/mosaic/full-session-agent.ts
+++ b/pi/agent/extensions/mosaic/full-session-agent.ts
@@ -28,6 +28,7 @@ export interface FullSessionLaunchOptions {
 	isolated?: boolean;
 	inheritContext?: boolean;
 	isolation?: IsolationMode;
+	cwd?: string;
 	agentConfig?: AgentConfig;
 	messageEndpoint?: string;
 	messageToken?: string;
@@ -63,10 +64,10 @@ export async function launchFullSessionAgent(
 	options: FullSessionLaunchOptions,
 ): Promise<FullSessionLaunchResult> {
 	const id = options.id ?? randomUUID().slice(0, 17);
-	let effectiveCwd = ctx.cwd;
+	let effectiveCwd = options.cwd ?? ctx.cwd;
 	let worktree: { path: string; branch: string } | undefined;
 	if (options.isolation === "worktree") {
-		const created = createWorktree(ctx.cwd, id);
+		const created = createWorktree(effectiveCwd, id);
 		if (!created) {
 			throw new Error(
 				'Cannot run with isolation: "worktree" — not a git repo, no commits yet, or `git worktree add` failed. ' +

--- a/pi/agent/extensions/mosaic/index.ts
+++ b/pi/agent/extensions/mosaic/index.ts
@@ -27,6 +27,7 @@ import { BUILTIN_TOOL_NAMES, getAgentConfig, getAllTypes, registerAgents, resolv
 import { isMosaicChildSession, registerMosaicBootstrap } from "./bootstrap.js";
 import { registerRpcHandlers } from "./cross-extension-rpc.js";
 import { loadCustomAgents } from "./custom-agents.js";
+import { resolveAgentCwd } from "./cwd.js";
 import { launchFullSessionAgent } from "./full-session-agent.js";
 import { isTerminalAssistantMessage, resolveFullSessionAgentStatus } from "./full-session-status.js";
 import { GroupJoinManager } from "./group-join.js";
@@ -69,6 +70,7 @@ interface FullSessionAgentRecord {
 	paneId: string;
 	windowId: string;
 	windowName: string;
+	cwd?: string;
 	startedAt: number;
 	status: "running" | "completed" | "error" | "stopped";
 	completedAt?: number;
@@ -714,9 +716,11 @@ export default function (pi: ExtensionAPI) {
 		model?: string;
 		thinking?: string;
 		isolation?: "worktree";
+		cwd?: string;
 	}) {
 		if (!currentCtx) throw new Error("No active session");
 		if (!hasMultiplexer()) throw new Error("mosaic requires tmux or an active zellij session");
+		const agentCwd = resolveAgentCwd(input.cwd, currentCtx.cwd);
 		const rawType = input.agentType ?? "general-purpose";
 		const subagentType = resolveType(rawType) ?? "general-purpose";
 		const customConfig = getAgentConfig(subagentType);
@@ -745,6 +749,7 @@ export default function (pi: ExtensionAPI) {
 				model: model as any,
 				thinkingLevel: input.thinking as any,
 				isolation: input.isolation,
+				cwd: agentCwd,
 				agentConfig: customConfig,
 				messageEndpoint: transport.endpoint,
 				messageToken: connection.token,
@@ -762,6 +767,7 @@ export default function (pi: ExtensionAPI) {
 			paneId: launched.paneId,
 			windowId: launched.windowId,
 			windowName: launched.windowName,
+			cwd: launched.cwd,
 			startedAt,
 			status: "running",
 			worktree: launched.worktree,

--- a/pi/agent/extensions/mosaic/schedule.ts
+++ b/pi/agent/extensions/mosaic/schedule.ts
@@ -43,6 +43,7 @@ export interface NewJobInput {
 	max_turns?: number;
 	isolated?: boolean;
 	isolation?: IsolationMode;
+	cwd?: string;
 }
 
 export class SubagentScheduler {
@@ -106,6 +107,7 @@ export class SubagentScheduler {
 			max_turns: input.max_turns,
 			isolated: input.isolated,
 			isolation: input.isolation,
+			cwd: input.cwd,
 			enabled: true,
 			createdAt: new Date().toISOString(),
 			runCount: 0,
@@ -247,6 +249,7 @@ export class SubagentScheduler {
 				isolated: job.isolated,
 				thinkingLevel: job.thinking,
 				isolation: job.isolation,
+				cwd: job.cwd,
 			});
 		} catch (err) {
 			const error = err instanceof Error ? err.message : String(err);

--- a/pi/agent/extensions/mosaic/types.ts
+++ b/pi/agent/extensions/mosaic/types.ts
@@ -149,6 +149,7 @@ export interface ScheduledSubagent {
 	max_turns?: number;
 	isolated?: boolean;
 	isolation?: IsolationMode;
+	cwd?: string;
 
 	// state
 	enabled: boolean;

--- a/pi/agent/extensions/mosaic/ui/schedule-menu.ts
+++ b/pi/agent/extensions/mosaic/ui/schedule-menu.ts
@@ -58,6 +58,7 @@ function formatDetails(j: ScheduledSubagent, scheduler: SubagentScheduler): stri
 		`name:      ${j.name}`,
 		`schedule:  ${j.schedule} (${j.scheduleType})`,
 		`agent:     ${j.subagent_type}`,
+		`cwd:       ${j.cwd ?? "parent session"}`,
 		`prompt:    ${j.prompt.slice(0, 200)}${j.prompt.length > 200 ? "…" : ""}`,
 		`created:   ${j.createdAt}`,
 		`last run:  ${j.lastRun ?? "—"} (${j.lastStatus ?? "—"})`,

--- a/pi/agent/extensions/mosaic/v2-tools.test.ts
+++ b/pi/agent/extensions/mosaic/v2-tools.test.ts
@@ -57,6 +57,31 @@ describe("createMosaicV2Tools", () => {
 		expect(contexts).toEqual([{ ui: "fake-ui" }]);
 	});
 
+	test("passes spawn cwd through to the mosaic agent launcher", async () => {
+		const spawns: unknown[] = [];
+		const tools = createMosaicV2Tools({
+			...fakeDeps(),
+			spawnAgent: async (input) => {
+				spawns.push(input);
+				return { agentId: "agent-1" };
+			},
+		});
+
+		await tools
+			.find((tool) => tool.name === "spawn_agent")
+			?.execute("1", {
+				task_name: "nested/task",
+				message: "work there",
+				cwd: "packages/app",
+			} as never);
+
+		expect(spawns[0]).toMatchObject({
+			taskName: "nested/task",
+			message: "work there",
+			cwd: "packages/app",
+		});
+	});
+
 	test("wait_agent delegates to mailbox sequence waiting", async () => {
 		const waited: Array<{ afterSeq?: number; timeoutMs?: number }> = [];
 		const tools = createMosaicV2Tools({

--- a/pi/agent/extensions/mosaic/v2-tools.ts
+++ b/pi/agent/extensions/mosaic/v2-tools.ts
@@ -22,6 +22,7 @@ export interface MosaicV2ToolDeps {
 		model?: string;
 		thinking?: string;
 		isolation?: "worktree";
+		cwd?: string;
 	}): Promise<unknown>;
 	sendMessage(input: { target: string; message: string; triggerTurn: boolean }): Promise<unknown>;
 	waitAgent(input: { afterSeq?: number; timeoutMs?: number }): Promise<unknown>;
@@ -63,6 +64,11 @@ export function createMosaicV2Tools(deps: MosaicV2ToolDeps) {
 				model: Type.Optional(Type.String({ description: "Optional model." })),
 				thinking: Type.Optional(Type.String({ description: "Thinking level." })),
 				isolation: Type.Optional(Type.Literal("worktree", { description: "Use a worktree." })),
+				cwd: Type.Optional(
+					Type.String({
+						description: "Working directory for the agent. Absolute or relative to the parent session cwd.",
+					}),
+				),
 			}),
 			renderShell: "self" as const,
 			renderCall: () => emptyMosaicRender,
@@ -77,6 +83,7 @@ export function createMosaicV2Tools(deps: MosaicV2ToolDeps) {
 						model: params.model,
 						thinking: params.thinking,
 						isolation: params.isolation,
+						cwd: params.cwd,
 					}),
 				);
 			},


### PR DESCRIPTION
## Summary
- add a cwd parameter to mosaic spawn_agent so agents can run from nested or alternate working directories
- resolve relative cwd values from the parent session cwd and validate they are directories
- carry cwd through full-session launch, queued/scheduled agent spawns, and schedule details

## Verification
- bun test pi/agent/extensions/mosaic/cwd.test.ts pi/agent/extensions/mosaic/v2-tools.test.ts pi/agent/extensions/mosaic/index.test.ts

Note: full pre-commit check hit existing environment-dependent exec-command TTY failures on this machine after Biome formatting passed; the focused mosaic tests pass.