### PR TITLE
feat(plannotator-hub): proxy plannotator sessions through one public origin

### DIFF
--- a/docs/plannotator-hub.md
+++ b/docs/plannotator-hub.md
@@ -1,0 +1,173 @@
+# Plannotator hub for Pi
+
+This repo ships a Pi-side Plannotator hub that keeps upstream Plannotator
+unchanged while solving two operational problems:
+
+1. upstream Plannotator starts a fresh localhost server for every plan/review
+2. those random localhost ports are not remotely accessible on their own
+
+The hub exposes one stable public origin and proxies active Plannotator sessions
+through it.
+
+## What it does
+
+- keeps real Plannotator review servers on random `127.0.0.1:<port>` listeners
+- runs a hub on one fixed port, default `19432`
+- registers each new backend through a browser shim
+- serves a picker UI at `/`
+- proxies each session at `/s/<session-id>/`
+
+This matters because upstream Plannotator's browser bundles call absolute API
+paths like `/api/plan` and `/api/feedback`. The hub rewrites those root paths
+to `/s/<session-id>/api/...` on the way out, so the browser stays on the single
+public origin.
+
+## Files
+
+- `pi/agent/extensions/plannotator-hub/index.ts`
+  - Pi extension that wires environment variables for the hub
+- `pi/agent/extensions/plannotator-hub/browser-shim.cjs`
+  - executable opened by upstream Plannotator instead of a normal browser
+- `pi/agent/extensions/plannotator-hub/hub-server.cjs`
+  - standalone proxy + picker UI process
+
+## How the wiring works
+
+When Pi starts a session, the local extension:
+
+- forces `PLANNOTATOR_REMOTE=false`
+- clears `PLANNOTATOR_PORT`
+- points Plannotator's browser launcher at the local browser shim
+- stores current Pi session metadata in env vars so the shim can label entries
+
+That keeps upstream Plannotator off the fixed public port and ensures it opens
+random loopback listeners only.
+
+When upstream Plannotator tries to open a browser tab, it actually launches the
+browser shim:
+
+1. ensure the hub is running on `PLANNOTATOR_HUB_PORT`
+2. probe the backend (`/api/plan` or `/api/diff`) to identify plan/review mode
+3. register the backend with the hub
+4. optionally open the public session URL in a local browser
+
+Remote SSH sessions normally do not have a GUI browser, so step 4 is best
+effort.
+
+## Pi-native configuration
+
+Use Pi settings as the primary source of truth. This repo ships the shared
+default in `pi/agent/settings.json`, which `just setup` links into Pi's global
+settings location.
+
+The shared default is:
+
+```json
+{
+  "plannotatorHub": {
+    "publicUrl": "http://127.0.0.1:19432",
+    "port": 19432,
+    "bind": "127.0.0.1"
+  }
+}
+```
+
+If you want a personal remote tunnel, override `plannotatorHub.publicUrl` in a
+local `.pi/settings.json`. Project settings override global settings, matching
+normal Pi behavior.
+
+After changing the `plannotatorHub` block, run `/reload` in Pi or start a new
+Pi session so the extension re-reads settings and restarts the hub with the new
+values.
+
+## Default configuration
+
+When no `plannotatorHub` settings exist, the extension falls back to:
+
+```bash
+PLANNOTATOR_HUB_PORT=19432
+PLANNOTATOR_HUB_BIND=127.0.0.1
+PLANNOTATOR_HUB_PUBLIC_URL=http://127.0.0.1:19432
+```
+
+### Fallback environment override
+
+For ad hoc launches outside settings, you can still set a custom public origin:
+
+```bash
+PLANNOTATOR_HUB_PUBLIC_URL=https://your-plannotator-host.example.com
+```
+
+Settings override stale inherited hub env inside the running Pi process. The
+env var remains useful for one-off tests.
+
+## Optional remote tunnel setup
+
+If you want remote access, point your own tunnel or reverse proxy at the local
+hub:
+
+- origin service: `http://127.0.0.1:19432`
+
+No other ports need to be exposed. The hub proxies the random Plannotator
+backends through the same origin.
+
+Because the hub is a generic proxy to active localhost Plannotator sessions,
+put authentication in front of it. Cloudflare Access is the intended guardrail.
+
+The hub now starts automatically when Pi starts a session. If Pi is not
+running, your remote origin still has nothing local to proxy to, so a gateway
+error is expected.
+
+## Optional environment variables
+
+### `PLANNOTATOR_HUB_OPEN_BROWSER`
+
+If set, the shim uses this command to open the public session URL after
+registration. This is mainly for local desktop Pi sessions.
+
+### `PLANNOTATOR_HUB_SECRET_FILE`
+
+Path to the local shared secret used by the browser shim when registering
+backends with the hub. Default:
+
+```bash
+~/.pi/plannotator-hub-secret
+```
+
+The secret protects the registration endpoint from arbitrary public callers.
+
+### `PLANNOTATOR_HUB_DISABLED`
+
+Set to `1` or `true` to disable the hub wiring entirely.
+
+## Local workflow
+
+1. run `just setup`
+2. run `/reload` or start a fresh Pi session
+3. open `http://127.0.0.1:19432/`
+4. trigger any Plannotator plan/review/annotate flow
+5. pick the session from the hub UI
+
+If you want remote access instead, add a local `.pi/settings.json` override
+with your own `plannotatorHub.publicUrl` and point your tunnel at
+`127.0.0.1:19432`.
+
+## Current limitations
+
+- the picker UI is intentionally simple: list + open
+- session registry is in-memory inside the hub process
+- if the hub restarts, existing backends must register again on the next browser launch
+- HTML rewriting assumes upstream Plannotator continues to reference root
+  endpoints like `/api/...` and `/favicon.svg`
+
+## Why this is upstreamable
+
+Most of the work is setup and orchestration, not Plannotator core changes:
+
+- a fixed-port hub process
+- a browser shim
+- path rewriting for root-relative API calls
+- Pi-side settings + environment wiring
+
+That means the shape can move upstream later without changing the semantics of
+Plannotator's own plan/review servers.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:skillful": "bun test pi/agent/extensions/skillful/index.test.ts pi/agent/extensions/tui/editor.test.ts pi/agent/extensions/tui/git.test.ts",
     "test:system-prompt": "bun test pi/agent/extensions/agents-local/index.test.ts pi/agent/extensions/system-prompt/index.test.ts pi/agent/extensions/token-burden/parser.test.ts",
     "test:git-tool": "bun test pi/agent/extensions/git-tool/index.test.ts",
-    "test:vault": "bun test pi/agent/extensions/plannotator-events/index.test.ts pi/agent/extensions/vault/index.test.ts",
+    "test:vault": "bun test pi/agent/extensions/plannotator-events/index.test.ts pi/agent/extensions/plannotator-hub/index.test.ts pi/agent/extensions/vault/index.test.ts",
     "test:skills": "bun test skills/start.test.ts",
     "test:codex-native": "bun test pi/agent/extensions/apply-patch/index.test.ts pi/agent/extensions/codex-native/index.test.ts pi/agent/extensions/exec-command/index.test.ts pi/agent/extensions/token-burden/tool-toggles.test.ts pi/agent/extensions/token-burden/report-view.test.ts pi/agent/extensions/token-burden/parser.test.ts pi/agent/extensions/token-burden/index.test.ts pi/agent/extensions/tui/editor.test.ts",
     "test:compaction": "bun test pi/agent/extensions/codex-native/compaction/src/unit.test.ts pi/agent/extensions/codex-native/compaction/src/validation.test.ts pi/agent/extensions/vcc/src/hooks/before-compact.test.ts pi/agent/extensions/vcc/src/commands/vcc.test.ts",

--- a/pi/agent/extensions/plannotator-hub/browser-shim.cjs
+++ b/pi/agent/extensions/plannotator-hub/browser-shim.cjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+
+const { existsSync, readFileSync } = require("node:fs");
+const { spawn } = require("node:child_process");
+const {
+	describePlanPayload,
+	describeReviewPayload,
+	hubLocalBaseUrl,
+	validateBackendUrl,
+} = require("./shared.cjs");
+
+function sessionContextFromEnv() {
+	return {
+		sessionId: process.env.PLANNOTATOR_HUB_SESSION_ID,
+		sessionFile: process.env.PLANNOTATOR_HUB_SESSION_FILE,
+		sessionName: process.env.PLANNOTATOR_HUB_SESSION_NAME,
+		cwd: process.env.PLANNOTATOR_HUB_SESSION_CWD,
+	};
+}
+
+function secretFilePath() {
+	return process.env.PLANNOTATOR_HUB_SECRET_FILE || `${process.env.HOME || ""}/.pi/plannotator-hub-secret`;
+}
+
+function readSecret() {
+	const path = secretFilePath();
+	if (!existsSync(path)) return undefined;
+	return readFileSync(path, "utf8").trim();
+}
+
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function healthcheck(baseUrl) {
+	try {
+		const response = await fetch(`${baseUrl}/api/health`, {
+			signal: AbortSignal.timeout(1000),
+			cache: "no-store",
+		});
+		return response.ok;
+	} catch {
+		return false;
+	}
+}
+
+function spawnHub() {
+	const script = process.env.PLANNOTATOR_HUB_SCRIPT;
+	if (!script) throw new Error("PLANNOTATOR_HUB_SCRIPT is not set");
+	const child = spawn(process.execPath, [script], {
+		detached: true,
+		stdio: "ignore",
+		env: process.env,
+	});
+	child.unref();
+}
+
+async function ensureHubReady() {
+	const baseUrl = hubLocalBaseUrl(process.env);
+	if (await healthcheck(baseUrl)) return baseUrl;
+	spawnHub();
+	for (let attempt = 0; attempt < 20; attempt += 1) {
+		await sleep(250);
+		if (await healthcheck(baseUrl)) return baseUrl;
+	}
+	throw new Error(`Plannotator hub did not become ready at ${baseUrl}`);
+}
+
+async function fetchJson(url) {
+	try {
+		const response = await fetch(url, {
+			headers: { accept: "application/json" },
+			signal: AbortSignal.timeout(1500),
+			cache: "no-store",
+		});
+		if (!response.ok) return null;
+		return await response.json();
+	} catch {
+		return null;
+	}
+}
+
+async function probeBackend(backendUrl) {
+	const planData = await fetchJson(`${backendUrl}/api/plan`);
+	if (planData && typeof planData.plan === "string") {
+		return describePlanPayload(planData);
+	}
+	const diffData = await fetchJson(`${backendUrl}/api/diff`);
+	if (diffData && typeof diffData.rawPatch === "string") {
+		return describeReviewPayload(diffData);
+	}
+	return {
+		kind: "plan",
+		title: "Plannotator session",
+	};
+}
+
+async function registerSession(baseUrl, backendUrl) {
+	const details = await probeBackend(backendUrl);
+	const secret = readSecret();
+	if (!secret) throw new Error("Plannotator hub secret is not available");
+
+	const response = await fetch(`${baseUrl}/api/register`, {
+		method: "POST",
+		headers: {
+			authorization: `Bearer ${secret}`,
+			"content-type": "application/json",
+		},
+		body: JSON.stringify({
+			backendUrl,
+			...details,
+			...sessionContextFromEnv(),
+		}),
+		signal: AbortSignal.timeout(3000),
+	});
+	if (!response.ok) {
+		throw new Error(`Registration failed with ${response.status}`);
+	}
+	return response.json();
+}
+
+function explicitBrowserCommand() {
+	const command = process.env.PLANNOTATOR_HUB_OPEN_BROWSER;
+	if (!command) return null;
+	if (command === __filename) return null;
+	return command;
+}
+
+function openWithCommand(command, url) {
+	const child = spawn(command, [url], {
+		detached: true,
+		stdio: "ignore",
+		shell: process.platform === "win32",
+	});
+	child.once("error", () => {});
+	child.unref();
+}
+
+function openPublicUrl(url) {
+	const remote = process.env.SSH_TTY || process.env.SSH_CONNECTION;
+	const explicit = explicitBrowserCommand();
+	if (explicit) {
+		openWithCommand(explicit, url);
+		return true;
+	}
+	if (remote) return false;
+
+	try {
+		if (process.platform === "darwin") {
+			openWithCommand("open", url);
+			return true;
+		}
+		if (process.platform === "win32") {
+			const child = spawn("cmd.exe", ["/c", "start", "", url], {
+				detached: true,
+				stdio: "ignore",
+			});
+			child.once("error", () => {});
+			child.unref();
+			return true;
+		}
+		openWithCommand("xdg-open", url);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function main() {
+	const rawBackendUrl = process.argv[2];
+	if (!rawBackendUrl) return;
+
+	const validated = validateBackendUrl(rawBackendUrl, Number(process.env.PLANNOTATOR_HUB_PORT || "19432"));
+	if (!validated.ok) return;
+
+	try {
+		const baseUrl = await ensureHubReady();
+		const registration = await registerSession(baseUrl, validated.url);
+		const targetUrl = typeof registration?.url === "string" ? registration.url : rawBackendUrl;
+		openPublicUrl(targetUrl);
+	} catch {
+		openPublicUrl(rawBackendUrl);
+	}
+}
+
+void main();

--- a/pi/agent/extensions/plannotator-hub/hub-server.cjs
+++ b/pi/agent/extensions/plannotator-hub/hub-server.cjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+const { createServer } = require("node:http");
+const { mkdirSync, readFileSync, writeFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { dirname, join } = require("node:path");
+const { randomBytes } = require("node:crypto");
+const { Readable } = require("node:stream");
+const { pipeline } = require("node:stream/promises");
+const {
+	DEFAULT_BIND_HOST,
+	DEFAULT_HUB_PORT,
+	DEFAULT_PUBLIC_URL,
+	buildPublicSessionUrl,
+	normalizePublicBaseUrl,
+	rewriteHtmlForSession,
+	summarizeSession,
+	validateBackendUrl,
+	newSessionId,
+} = require("./shared.cjs");
+
+const SESSION_TTL_MS = 12 * 60 * 60 * 1000;
+const SECRET_PATH = process.env.PLANNOTATOR_HUB_SECRET_FILE || join(homedir(), ".pi", "plannotator-hub-secret");
+
+function ensureSecret() {
+	if (existsSync(SECRET_PATH)) {
+		return readFileSync(SECRET_PATH, "utf8").trim();
+	}
+	mkdirSync(dirname(SECRET_PATH), { recursive: true });
+	const secret = randomBytes(24).toString("hex");
+	writeFileSync(SECRET_PATH, `${secret}\n`, { mode: 0o600 });
+	return secret;
+}
+
+function json(res, status, payload) {
+	const body = JSON.stringify(payload, null, 2);
+	res.writeHead(status, {
+		"content-type": "application/json; charset=utf-8",
+		"cache-control": "no-store",
+		"content-length": Buffer.byteLength(body),
+	});
+	res.end(body);
+}
+
+function text(res, status, body, headers = {}) {
+	res.writeHead(status, {
+		"content-type": "text/html; charset=utf-8",
+		"cache-control": "no-store",
+		"content-length": Buffer.byteLength(body),
+		...headers,
+	});
+	res.end(body);
+}
+
+function escapeHtml(value) {
+	return String(value || "")
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;");
+}
+
+function requireSecret(req, expected) {
+	const raw = req.headers.authorization || "";
+	return raw === `Bearer ${expected}`;
+}
+
+function removeSession(state, sessionId) {
+	const entry = state.sessions.get(sessionId);
+	if (!entry) return false;
+	state.sessions.delete(sessionId);
+	if (state.sessionIdsByBackend.get(entry.backendUrl) === sessionId) {
+		state.sessionIdsByBackend.delete(entry.backendUrl);
+	}
+	return true;
+}
+
+function pruneSessions(state) {
+	const now = Date.now();
+	for (const [id, entry] of state.sessions) {
+		if (now - entry.updatedAt > SESSION_TTL_MS) {
+			removeSession(state, id);
+		}
+	}
+}
+
+async function isBackendAlive(entry) {
+	try {
+		const response = await fetch(`${entry.backendUrl}/api/health`, {
+			method: "GET",
+			cache: "no-store",
+			signal: AbortSignal.timeout(1_000),
+		});
+		return response.ok || response.status === 404;
+	} catch {
+		return false;
+	}
+}
+
+async function pruneDeadSessions(state) {
+	const entries = [...state.sessions.entries()];
+	await Promise.all(
+		entries.map(async ([sessionId, entry]) => {
+			if (!(await isBackendAlive(entry))) removeSession(state, sessionId);
+		}),
+	);
+}
+
+function renderHubPage() {
+	return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Plannotator Hub</title>
+  <style>
+    :root { color-scheme: light dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+    body { margin: 0; background: #0b1020; color: #e6edf7; }
+    main { max-width: 1080px; margin: 0 auto; padding: 24px; }
+    h1 { margin: 0 0 8px; font-size: 28px; }
+    p { color: #9db0cf; }
+    .meta { display: flex; gap: 12px; flex-wrap: wrap; margin: 16px 0 24px; }
+    .pill { border: 1px solid #2d3a57; border-radius: 999px; padding: 6px 10px; font-size: 12px; color: #b8c5db; }
+    .sessions { display: grid; gap: 12px; }
+    .card { background: #121a2b; border: 1px solid #23304d; border-radius: 14px; padding: 16px; display: grid; gap: 10px; }
+    .row { display: flex; justify-content: space-between; align-items: center; gap: 16px; flex-wrap: wrap; }
+    .kind { text-transform: uppercase; letter-spacing: .08em; font-size: 11px; color: #75a7ff; }
+    .title { font-size: 18px; font-weight: 600; }
+    .details { display: grid; gap: 4px; font-size: 13px; color: #9db0cf; }
+    a.button { text-decoration: none; background: #4f8cff; color: white; padding: 8px 12px; border-radius: 10px; font-weight: 600; }
+    .empty { border: 1px dashed #334160; border-radius: 14px; padding: 24px; color: #9db0cf; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Plannotator Hub</h1>
+    <p>Active Plannotator sessions proxied through one exposed port.</p>
+    <div class="meta">
+      <div class="pill">Path proxy: <code>/s/&lt;session&gt;/</code></div>
+      <div class="pill">Auto-refresh: 5s</div>
+    </div>
+    <section id="sessions" class="sessions">
+      <div class="empty">Waiting for a Plannotator session to register.</div>
+    </section>
+  </main>
+  <script>
+    const sessionsNode = document.getElementById("sessions");
+    function fmtDate(value) {
+      try { return new Date(value).toLocaleString(); } catch { return value; }
+    }
+    function renderSessions(items) {
+      if (!Array.isArray(items) || items.length === 0) {
+        sessionsNode.innerHTML = '<div class="empty">Waiting for a Plannotator session to register.</div>';
+        return;
+      }
+      sessionsNode.innerHTML = items.map((item) => {
+        const details = [
+          item.repoDisplay ? 'Repo: ' + item.repoDisplay : '',
+          item.resource ? 'Target: ' + item.resource : '',
+          item.cwd ? 'CWD: ' + item.cwd : '',
+          item.sessionName ? 'Pi session: ' + item.sessionName : (item.sessionFile ? 'Pi session file: ' + item.sessionFile : ''),
+          'Updated: ' + fmtDate(item.updatedAt),
+        ].filter(Boolean).map((text) => '<div>' + escapeHtml(text) + '</div>').join('');
+        return \`
+          <article class="card">
+            <div class="row">
+              <div>
+                <div class="kind">\${escapeHtml(item.kind || "session")}</div>
+                <div class="title">\${escapeHtml(item.title || "Untitled")}</div>
+              </div>
+              <a class="button" href="\${item.url}" target="_blank" rel="noreferrer">Open</a>
+            </div>
+            <div class="details">\${details}</div>
+          </article>\`;
+      }).join('');
+    }
+    function escapeHtml(value) {
+      return String(value ?? '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;');
+    }
+    async function refresh() {
+      try {
+        const response = await fetch('/api/sessions', { cache: 'no-store' });
+        const data = await response.json();
+        renderSessions(data.sessions || []);
+      } catch (error) {
+        sessionsNode.innerHTML = '<div class="empty">Failed to load sessions.</div>';
+      }
+    }
+    refresh();
+    setInterval(refresh, 5000);
+  </script>
+</body>
+</html>`;
+}
+
+async function readJson(req) {
+	const chunks = [];
+	for await (const chunk of req) chunks.push(chunk);
+	const body = Buffer.concat(chunks).toString("utf8");
+	return body ? JSON.parse(body) : {};
+}
+
+function proxyHeaders(reqHeaders) {
+	const headers = new Headers();
+	for (const [key, value] of Object.entries(reqHeaders)) {
+		if (value == null) continue;
+		const lower = key.toLowerCase();
+		if (["host", "connection", "content-length", "accept-encoding"].includes(lower)) continue;
+		if (Array.isArray(value)) {
+			for (const item of value) headers.append(key, item);
+		} else {
+			headers.set(key, value);
+		}
+	}
+	return headers;
+}
+
+function shouldRewriteHtml(upstream, targetPath) {
+	const contentType = upstream.headers.get("content-type") || "";
+	return contentType.includes("text/html") || targetPath === "/";
+}
+
+async function pipeUpstreamBodyToResponse(body, res) {
+	await pipeline(Readable.fromWeb(body), res);
+}
+
+async function proxyToBackend(state, req, res, session, targetPath, search) {
+	const targetUrl = new URL(`${targetPath}${search}`, `${session.backendUrl}/`);
+	const init = {
+		method: req.method,
+		headers: proxyHeaders(req.headers),
+		redirect: "manual",
+	};
+	if (req.method !== "GET" && req.method !== "HEAD") {
+		init.body = Readable.toWeb(req);
+		init.duplex = "half";
+	}
+
+	const upstream = await fetch(targetUrl, init);
+	session.updatedAt = Date.now();
+
+	if (shouldRewriteHtml(upstream, targetPath)) {
+		const html = await upstream.text();
+		const body = rewriteHtmlForSession(html, session.id);
+		const headers = {};
+		for (const [key, value] of upstream.headers.entries()) {
+			if (["content-length", "content-encoding"].includes(key.toLowerCase())) continue;
+			headers[key] = value;
+		}
+		text(res, upstream.status, body, headers);
+		return;
+	}
+
+	for (const [key, value] of upstream.headers.entries()) {
+		if (key.toLowerCase() === "content-length") continue;
+		res.setHeader(key, value);
+	}
+	res.statusCode = upstream.status;
+	if (!upstream.body) {
+		res.end();
+		return;
+	}
+	await pipeUpstreamBodyToResponse(upstream.body, res);
+}
+
+function createState() {
+	return {
+		publicBaseUrl: normalizePublicBaseUrl(process.env.PLANNOTATOR_HUB_PUBLIC_URL || DEFAULT_PUBLIC_URL),
+		secret: ensureSecret(),
+		sessions: new Map(),
+		sessionIdsByBackend: new Map(),
+	};
+}
+
+function upsertSession(state, payload) {
+	const existingId = state.sessionIdsByBackend.get(payload.backendUrl);
+	const existing = existingId ? state.sessions.get(existingId) : undefined;
+	const id = existing?.id || newSessionId();
+	const url = buildPublicSessionUrl(state.publicBaseUrl, id);
+	const now = Date.now();
+	const entry = {
+		id,
+		url,
+		backendUrl: payload.backendUrl,
+		kind: payload.kind || existing?.kind || "plan",
+		mode: payload.mode || existing?.mode,
+		title: payload.title || existing?.title || "Plannotator session",
+		repoDisplay: payload.repoDisplay || existing?.repoDisplay,
+		resource: payload.resource || existing?.resource,
+		sessionId: payload.sessionId || existing?.sessionId,
+		sessionName: payload.sessionName || existing?.sessionName,
+		sessionFile: payload.sessionFile || existing?.sessionFile,
+		cwd: payload.cwd || existing?.cwd,
+		createdAt: existing?.createdAt || now,
+		updatedAt: now,
+	};
+	state.sessions.set(id, entry);
+	state.sessionIdsByBackend.set(entry.backendUrl, id);
+	return entry;
+}
+
+async function startServer() {
+	const state = createState();
+	const hubPort = Number(process.env.PLANNOTATOR_HUB_PORT || DEFAULT_HUB_PORT);
+	const bindHost = process.env.PLANNOTATOR_HUB_BIND || DEFAULT_BIND_HOST;
+	const server = createServer(async (req, res) => {
+		try {
+			pruneSessions(state);
+			const url = new URL(req.url || "/", "http://127.0.0.1");
+
+			if (url.pathname === "/api/health") {
+				json(res, 200, { ok: true });
+				return;
+			}
+
+			if (url.pathname === "/api/sessions") {
+				await pruneDeadSessions(state);
+				const sessions = [...state.sessions.values()]
+					.sort((left, right) => right.updatedAt - left.updatedAt)
+					.map((entry) => summarizeSession(entry));
+				json(res, 200, { sessions });
+				return;
+			}
+
+			if (url.pathname === "/api/register" && req.method === "POST") {
+				if (!requireSecret(req, state.secret)) {
+					json(res, 401, { error: "Unauthorized" });
+					return;
+				}
+				const payload = await readJson(req);
+				const validated = validateBackendUrl(payload.backendUrl, hubPort);
+				if (!validated.ok) {
+					json(res, 400, { error: validated.reason });
+					return;
+				}
+				const entry = upsertSession(state, { ...payload, backendUrl: validated.url });
+				json(res, 200, { id: entry.id, url: entry.url });
+				return;
+			}
+
+			if (url.pathname === "/api/unregister" && req.method === "POST") {
+				if (!requireSecret(req, state.secret)) {
+					json(res, 401, { error: "Unauthorized" });
+					return;
+				}
+				const payload = await readJson(req);
+				const sessionId = typeof payload?.id === "string" ? payload.id : "";
+				if (!sessionId) {
+					json(res, 400, { error: "Missing session id" });
+					return;
+				}
+				json(res, 200, { removed: removeSession(state, sessionId) });
+				return;
+			}
+
+			if (url.pathname === "/") {
+				text(res, 200, renderHubPage());
+				return;
+			}
+
+			const match = url.pathname.match(/^\/s\/([^/]+)(\/.*)?$/u);
+			if (match) {
+				const sessionId = decodeURIComponent(match[1]);
+				const targetPath = match[2] || "/";
+				const session = state.sessions.get(sessionId);
+				if (!session) {
+					text(res, 404, "<h1>Unknown Plannotator session</h1>");
+					return;
+				}
+				if (!match[2]) {
+					res.writeHead(302, { location: `/s/${encodeURIComponent(sessionId)}/` });
+					res.end();
+					return;
+				}
+				if (!(await isBackendAlive(session))) {
+					removeSession(state, sessionId);
+					text(res, 404, "<h1>Closed Plannotator session</h1>");
+					return;
+				}
+				try {
+					await proxyToBackend(state, req, res, session, targetPath, url.search);
+				} catch (error) {
+					if (error instanceof Error && /(ECONNREFUSED|fetch failed|socket hang up)/i.test(error.message)) {
+						removeSession(state, sessionId);
+						text(res, 404, "<h1>Closed Plannotator session</h1>");
+						return;
+					}
+					throw error;
+				}
+				return;
+			}
+
+			text(res, 404, "<h1>Not found</h1>");
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			text(res, 500, `<h1>Plannotator hub error</h1><pre>${escapeHtml(message)}</pre>`);
+		}
+	});
+
+	server.listen(hubPort, bindHost, () => {
+		const address = state.publicBaseUrl;
+		process.stdout.write(`[plannotator-hub] listening on ${bindHost}:${hubPort} (public ${address})\n`);
+	});
+}
+
+if (require.main === module) {
+	startServer().catch((error) => {
+		process.stderr.write(`${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+		process.exitCode = 1;
+	});
+}
+
+module.exports = {
+	createState,
+	isBackendAlive,
+	pipeUpstreamBodyToResponse,
+	pruneDeadSessions,
+	removeSession,
+	renderHubPage,
+	startServer,
+};

--- a/pi/agent/extensions/plannotator-hub/index.test.ts
+++ b/pi/agent/extensions/plannotator-hub/index.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "bun:test";
+import { createRequire } from "node:module";
+import {
+	applyPlannotatorHubEnvironment,
+	setPlannotatorHubSettingsReaderForTests,
+	syncPlannotatorHubSessionContext,
+} from "./index";
+
+const require = createRequire(import.meta.url);
+const shared = require("./shared.cjs") as {
+	buildPublicSessionUrl: (publicBase: string, sessionId: string) => string;
+	describePlanPayload: (payload: Record<string, unknown>) => Record<string, unknown>;
+	describeReviewPayload: (payload: Record<string, unknown>) => Record<string, unknown>;
+	rewriteHtmlForSession: (html: string, sessionId: string) => string;
+	validateBackendUrl: (url: string, hubPort?: number) => { ok: boolean; url?: string };
+};
+const hubServer = require("./hub-server.cjs") as {
+	createState: () => {
+		sessions: Map<string, { backendUrl: string }>;
+		sessionIdsByBackend: Map<string, string>;
+	};
+	isBackendAlive: (entry: { backendUrl: string }) => Promise<boolean>;
+	pruneDeadSessions: (state: {
+		sessions: Map<string, { backendUrl: string }>;
+		sessionIdsByBackend: Map<string, string>;
+	}) => Promise<void>;
+	removeSession: (
+		state: {
+			sessions: Map<string, { backendUrl: string }>;
+			sessionIdsByBackend: Map<string, string>;
+		},
+		sessionId: string,
+	) => boolean;
+};
+
+describe("plannotator hub environment", () => {
+	test("forces upstream Plannotator onto random local ports and installs the browser shim", () => {
+		const env: NodeJS.ProcessEnv = {
+			PLANNOTATOR_PORT: "19432",
+			PLANNOTATOR_BROWSER: "/usr/bin/firefox",
+		};
+
+		applyPlannotatorHubEnvironment({ env });
+
+		expect(env.PLANNOTATOR_REMOTE).toBe("false");
+		expect(env.PLANNOTATOR_PORT).toBeUndefined();
+		expect(env.PLANNOTATOR_HUB_PORT).toBe("19432");
+		expect(env.PLANNOTATOR_HUB_SCRIPT).toContain("hub-server.cjs");
+		expect(env.PLANNOTATOR_BROWSER).toContain("browser-shim.cjs");
+		expect(env.PLANNOTATOR_HUB_OPEN_BROWSER).toBe("/usr/bin/firefox");
+	});
+
+	test("keeps the public URL when explicitly configured", () => {
+		const env: NodeJS.ProcessEnv = {
+			PLANNOTATOR_HUB_PUBLIC_URL: "https://plannotator.noxcraft.dev",
+		};
+
+		applyPlannotatorHubEnvironment({ env });
+
+		expect(env.PLANNOTATOR_HUB_PUBLIC_URL).toBe("https://plannotator.noxcraft.dev");
+	});
+
+	test("settings override stale env values", () => {
+		const restore = setPlannotatorHubSettingsReaderForTests(() => ({
+			enabled: true,
+			publicUrl: "https://plannotator.noxcraft.dev",
+			port: "19432",
+			bind: "127.0.0.1",
+		}));
+		const env: NodeJS.ProcessEnv = {
+			PLANNOTATOR_HUB_PUBLIC_URL: "http://127.0.0.1:19432",
+			PLANNOTATOR_HUB_PORT: "9999",
+			PLANNOTATOR_HUB_BIND: "0.0.0.0",
+		};
+
+		try {
+			applyPlannotatorHubEnvironment({ env, cwd: "/repo" });
+		} finally {
+			restore();
+		}
+
+		expect(env.PLANNOTATOR_HUB_PUBLIC_URL).toBe("https://plannotator.noxcraft.dev");
+		expect(env.PLANNOTATOR_HUB_PORT).toBe("19432");
+		expect(env.PLANNOTATOR_HUB_BIND).toBe("127.0.0.1");
+	});
+
+	test("settings can disable the hub wiring", () => {
+		const restore = setPlannotatorHubSettingsReaderForTests(() => ({
+			enabled: false,
+		}));
+		const env: NodeJS.ProcessEnv = {};
+
+		try {
+			applyPlannotatorHubEnvironment({ env, cwd: "/repo" });
+		} finally {
+			restore();
+		}
+
+		expect(env.PLANNOTATOR_HUB_PUBLIC_URL).toBeUndefined();
+		expect(env.PLANNOTATOR_BROWSER).toBeUndefined();
+	});
+
+	test("copies session metadata into environment variables", () => {
+		const env: NodeJS.ProcessEnv = {};
+		syncPlannotatorHubSessionContext(
+			{
+				cwd: "/repo",
+				sessionManager: {
+					getSessionId: () => "s-123",
+					getSessionFile: () => "/tmp/pi.jsonl",
+					getSessionName: () => "feature lane",
+				},
+			} as any,
+			env,
+		);
+
+		expect(env.PLANNOTATOR_HUB_SESSION_ID).toBe("s-123");
+		expect(env.PLANNOTATOR_HUB_SESSION_FILE).toBe("/tmp/pi.jsonl");
+		expect(env.PLANNOTATOR_HUB_SESSION_NAME).toBe("feature lane");
+		expect(env.PLANNOTATOR_HUB_SESSION_CWD).toBe("/repo");
+	});
+});
+
+describe("plannotator hub helpers", () => {
+	test("rejects non-loopback backend URLs", () => {
+		expect(shared.validateBackendUrl("https://example.com:1234")).toEqual({
+			ok: false,
+			reason: "backend URL must use http",
+		});
+		expect(shared.validateBackendUrl("http://10.0.0.8:1234")).toEqual({
+			ok: false,
+			reason: "backend URL must point at localhost",
+		});
+		expect(shared.validateBackendUrl("http://127.0.0.1:19432", 19432)).toEqual({
+			ok: false,
+			reason: "backend URL points at the hub port",
+		});
+	});
+
+	test("rewrites absolute backend API paths under a session prefix", () => {
+		const rewritten = shared.rewriteHtmlForSession(
+			`<script>fetch("/api/plan"); const icon = '/favicon.svg';</script>`,
+			"abc123",
+		);
+		expect(rewritten).toContain(`/s/abc123/api/plan`);
+		expect(rewritten).toContain(`/s/abc123/favicon.svg`);
+	});
+
+	test("builds a public session URL under the configured base path", () => {
+		expect(shared.buildPublicSessionUrl("https://plannotator.noxcraft.dev/base/", "abc123")).toBe(
+			"https://plannotator.noxcraft.dev/base/s/abc123/",
+		);
+	});
+
+	test("extracts plan and review labels for the picker UI", () => {
+		expect(
+			shared.describePlanPayload({
+				mode: "annotate",
+				filePath: "/repo/docs/plan.md",
+				plan: "# Hidden title",
+			}),
+		).toMatchObject({
+			kind: "annotate",
+			title: "plan.md",
+		});
+
+		expect(
+			shared.describeReviewPayload({
+				gitRef: "branch vs main",
+			}),
+		).toMatchObject({
+			kind: "review",
+			title: "branch vs main",
+		});
+	});
+
+	test("removes dead sessions from the registry", async () => {
+		const state = hubServer.createState();
+		state.sessions.set("closed", {
+			backendUrl: "http://127.0.0.1:9",
+		});
+		state.sessionIdsByBackend.set("http://127.0.0.1:9", "closed");
+
+		await hubServer.pruneDeadSessions(state);
+
+		expect(state.sessions.has("closed")).toBe(false);
+		expect(state.sessionIdsByBackend.has("http://127.0.0.1:9")).toBe(false);
+	});
+
+	test("removes live registry entries consistently", () => {
+		const state = hubServer.createState();
+		state.sessions.set("session-a", {
+			backendUrl: "http://127.0.0.1:3001",
+		});
+		state.sessionIdsByBackend.set("http://127.0.0.1:3001", "session-a");
+
+		expect(hubServer.removeSession(state, "session-a")).toBe(true);
+		expect(state.sessions.size).toBe(0);
+		expect(state.sessionIdsByBackend.size).toBe(0);
+	});
+});

--- a/pi/agent/extensions/plannotator-hub/index.ts
+++ b/pi/agent/extensions/plannotator-hub/index.ts
@@ -1,0 +1,207 @@
+import { spawn } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { SettingsManager } from "@earendil-works/pi-coding-agent";
+
+const DEFAULT_HUB_PORT = "19432";
+const DEFAULT_HUB_BIND = "127.0.0.1";
+const DISABLE_ENV = "PLANNOTATOR_HUB_DISABLED";
+const HUB_START_TIMEOUT_MS = 5_000;
+const missing = Symbol("plannotatorHubMissing");
+
+type UnknownRecord = Record<string, unknown>;
+type PlannotatorHubSettings = {
+	enabled?: unknown;
+	publicUrl?: unknown;
+	port?: unknown;
+	bind?: unknown;
+};
+
+function extensionDir() {
+	return dirname(fileURLToPath(import.meta.url));
+}
+
+export function getPlannotatorHubPaths() {
+	const dir = extensionDir();
+	return {
+		browserShimPath: resolve(dir, "browser-shim.cjs"),
+		hubServerPath: resolve(dir, "hub-server.cjs"),
+	};
+}
+
+function defaultPublicUrl(env: NodeJS.ProcessEnv) {
+	const port = env.PLANNOTATOR_HUB_PORT || DEFAULT_HUB_PORT;
+	return `http://127.0.0.1:${port}`;
+}
+
+function applyBrowserShim(env: NodeJS.ProcessEnv, browserShimPath: string) {
+	const existingBrowser = env.PLANNOTATOR_BROWSER || env.BROWSER;
+	if (!env.PLANNOTATOR_HUB_OPEN_BROWSER && existingBrowser && existingBrowser !== browserShimPath) {
+		env.PLANNOTATOR_HUB_OPEN_BROWSER = existingBrowser;
+	}
+
+	if (process.platform === "darwin") {
+		env.BROWSER = browserShimPath;
+		delete env.PLANNOTATOR_BROWSER;
+		return;
+	}
+
+	env.PLANNOTATOR_BROWSER = browserShimPath;
+}
+
+function parseString(value: unknown) {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function parsePort(value: unknown) {
+	if (typeof value === "number" && Number.isInteger(value) && value > 0 && value < 65536) {
+		return String(value);
+	}
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		if (/^\d+$/.test(trimmed)) {
+			const parsed = Number(trimmed);
+			if (parsed > 0 && parsed < 65536) return trimmed;
+		}
+	}
+	return undefined;
+}
+
+function parseEnabled(value: unknown) {
+	if (typeof value === "boolean") return value;
+	if (typeof value === "string") {
+		const normalized = value.trim().toLowerCase();
+		if (normalized === "true" || normalized === "1") return true;
+		if (normalized === "false" || normalized === "0") return false;
+	}
+	return undefined;
+}
+
+function readSetting(settings: unknown): PlannotatorHubSettings | typeof missing {
+	if (typeof settings !== "object" || settings === null || !Object.hasOwn(settings, "plannotatorHub")) return missing;
+	const value = (settings as UnknownRecord).plannotatorHub;
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return { enabled: value };
+	return value as PlannotatorHubSettings;
+}
+
+function readPlannotatorHubSettingsFromDisk(cwd: string) {
+	const settings = SettingsManager.create(cwd);
+	const project = readSetting(settings.getProjectSettings());
+	const global = readSetting(settings.getGlobalSettings());
+	const merged = {
+		...(global === missing ? {} : global),
+		...(project === missing ? {} : project),
+	};
+	return {
+		enabled: parseEnabled(merged.enabled),
+		publicUrl: parseString(merged.publicUrl),
+		port: parsePort(merged.port),
+		bind: parseString(merged.bind),
+	};
+}
+
+let plannotatorHubSettingsReader = readPlannotatorHubSettingsFromDisk;
+
+export function setPlannotatorHubSettingsReaderForTests(reader: typeof readPlannotatorHubSettingsFromDisk) {
+	const previous = plannotatorHubSettingsReader;
+	plannotatorHubSettingsReader = reader;
+	return () => {
+		plannotatorHubSettingsReader = previous;
+	};
+}
+
+export function readPlannotatorHubSettings(cwd: string) {
+	return plannotatorHubSettingsReader(cwd);
+}
+
+export function applyPlannotatorHubEnvironment(options: { env?: NodeJS.ProcessEnv; cwd?: string } = {}) {
+	const env = options.env ?? process.env;
+	const settings = readPlannotatorHubSettings(options.cwd ?? process.cwd());
+	if (settings.enabled === false || env[DISABLE_ENV] === "1" || env[DISABLE_ENV] === "true") return;
+
+	const { browserShimPath, hubServerPath } = getPlannotatorHubPaths();
+	env.PLANNOTATOR_HUB_PORT = settings.port ?? env.PLANNOTATOR_HUB_PORT ?? DEFAULT_HUB_PORT;
+	env.PLANNOTATOR_HUB_BIND = settings.bind ?? env.PLANNOTATOR_HUB_BIND ?? DEFAULT_HUB_BIND;
+	env.PLANNOTATOR_HUB_PUBLIC_URL = settings.publicUrl ?? env.PLANNOTATOR_HUB_PUBLIC_URL ?? defaultPublicUrl(env);
+	env.PLANNOTATOR_HUB_SCRIPT ||= hubServerPath;
+
+	// The hub owns the fixed public port. Upstream Plannotator must stay on random loopback ports.
+	env.PLANNOTATOR_REMOTE = "false";
+	delete env.PLANNOTATOR_PORT;
+	applyBrowserShim(env, browserShimPath);
+}
+
+function localHubBaseUrl(env: NodeJS.ProcessEnv = process.env) {
+	const host = env.PLANNOTATOR_HUB_BIND || DEFAULT_HUB_BIND;
+	const resolvedHost = host === "0.0.0.0" ? "127.0.0.1" : host;
+	const port = env.PLANNOTATOR_HUB_PORT || DEFAULT_HUB_PORT;
+	return `http://${resolvedHost}:${port}`;
+}
+
+async function isHubHealthy(env: NodeJS.ProcessEnv = process.env) {
+	try {
+		const response = await fetch(`${localHubBaseUrl(env)}/api/health`, {
+			cache: "no-store",
+			signal: AbortSignal.timeout(1_000),
+		});
+		return response.ok;
+	} catch {
+		return false;
+	}
+}
+
+function startHubProcess(env: NodeJS.ProcessEnv = process.env) {
+	const scriptPath = env.PLANNOTATOR_HUB_SCRIPT;
+	if (!scriptPath) return;
+	const child = spawn(process.execPath, [scriptPath], {
+		detached: true,
+		stdio: "ignore",
+		env,
+	});
+	child.once("error", () => {});
+	child.unref();
+}
+
+async function ensurePlannotatorHub(env: NodeJS.ProcessEnv = process.env) {
+	if (await isHubHealthy(env)) return;
+
+	startHubProcess(env);
+	const deadline = Date.now() + HUB_START_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, 250));
+		if (await isHubHealthy(env)) return;
+	}
+}
+
+function setOrDelete(env: NodeJS.ProcessEnv, key: string, value?: string) {
+	if (value) env[key] = value;
+	else delete env[key];
+}
+
+export function syncPlannotatorHubSessionContext(ctx: ExtensionContext, env: NodeJS.ProcessEnv = process.env) {
+	setOrDelete(env, "PLANNOTATOR_HUB_SESSION_ID", ctx.sessionManager.getSessionId());
+	setOrDelete(env, "PLANNOTATOR_HUB_SESSION_FILE", ctx.sessionManager.getSessionFile());
+	setOrDelete(env, "PLANNOTATOR_HUB_SESSION_NAME", ctx.sessionManager.getSessionName());
+	setOrDelete(env, "PLANNOTATOR_HUB_SESSION_CWD", ctx.cwd);
+}
+
+function clearPlannotatorHubSessionContext(env: NodeJS.ProcessEnv = process.env) {
+	delete env.PLANNOTATOR_HUB_SESSION_ID;
+	delete env.PLANNOTATOR_HUB_SESSION_FILE;
+	delete env.PLANNOTATOR_HUB_SESSION_NAME;
+	delete env.PLANNOTATOR_HUB_SESSION_CWD;
+}
+
+export default function plannotatorHubExtension(pi: ExtensionAPI): void {
+	applyPlannotatorHubEnvironment();
+	void ensurePlannotatorHub();
+	pi.on("session_start", async (_event, ctx) => {
+		applyPlannotatorHubEnvironment({ cwd: ctx.cwd });
+		syncPlannotatorHubSessionContext(ctx);
+		await ensurePlannotatorHub();
+	});
+	pi.on("session_shutdown", () => {
+		clearPlannotatorHubSessionContext();
+	});
+}

--- a/pi/agent/extensions/plannotator-hub/shared.cjs
+++ b/pi/agent/extensions/plannotator-hub/shared.cjs
@@ -1,0 +1,183 @@
+const { basename } = require("node:path");
+const { randomUUID } = require("node:crypto");
+
+const DEFAULT_HUB_PORT = 19432;
+const DEFAULT_BIND_HOST = "127.0.0.1";
+const DEFAULT_PUBLIC_URL = `http://${DEFAULT_BIND_HOST}:${DEFAULT_HUB_PORT}`;
+
+function ensureTrailingSlash(value) {
+	return value.endsWith("/") ? value : `${value}/`;
+}
+
+function truncateLabel(value, max = 96) {
+	const trimmed = String(value || "").replace(/\s+/g, " ").trim();
+	if (trimmed.length <= max) return trimmed;
+	return `${trimmed.slice(0, max - 1).trimEnd()}…`;
+}
+
+function stripMarkdown(value) {
+	return String(value || "")
+		.replace(/^\s{0,3}(#{1,6}|\*|-|\d+\.)\s+/u, "")
+		.replace(/[`*_~[\]]/gu, "")
+		.replace(/\((https?:\/\/[^)]+)\)/gu, "$1")
+		.trim();
+}
+
+function firstMeaningfulLine(text) {
+	const lines = String(text || "").split(/\r?\n/u);
+	for (const line of lines) {
+		const cleaned = stripMarkdown(line);
+		if (cleaned) return cleaned;
+	}
+	return "";
+}
+
+function extractPlanTitle(plan) {
+	const lines = String(plan || "").split(/\r?\n/u);
+	for (const line of lines) {
+		const heading = line.match(/^\s{0,3}#{1,6}\s+(.+)$/u);
+		if (heading?.[1]) return truncateLabel(stripMarkdown(heading[1]));
+	}
+	for (const line of lines) {
+		const checklist = line.match(/^\s*[-*]\s+\[[ xX]\]\s+(.+)$/u);
+		if (checklist?.[1]) return truncateLabel(stripMarkdown(checklist[1]));
+	}
+	return truncateLabel(firstMeaningfulLine(plan) || "Plan review");
+}
+
+function extractDiffTitle(rawPatch, gitRef) {
+	if (gitRef) return truncateLabel(gitRef);
+	const match = String(rawPatch || "").match(/^diff --git a\/(.+?) b\/(.+)$/mu);
+	if (match?.[2]) return truncateLabel(`Review ${match[2]}`);
+	return "Code review";
+}
+
+function normalizeKind(mode) {
+	if (typeof mode !== "string") return "plan";
+	if (mode.startsWith("annotate")) return "annotate";
+	if (mode === "archive") return "archive";
+	return "plan";
+}
+
+function describePlanPayload(data) {
+	const kind = normalizeKind(data?.mode);
+	return {
+		kind,
+		mode: typeof data?.mode === "string" ? data.mode : undefined,
+		title: truncateLabel(
+			stripMarkdown(data?.filePath ? basename(data.filePath) : "") ||
+				extractPlanTitle(data?.plan || ""),
+		),
+		resource: typeof data?.filePath === "string" ? data.filePath : data?.projectRoot,
+		repoDisplay: data?.repoInfo?.display,
+	};
+}
+
+function describeReviewPayload(data) {
+	return {
+		kind: "review",
+		mode: typeof data?.diffType === "string" ? data.diffType : undefined,
+		title: extractDiffTitle(data?.rawPatch || "", data?.gitRef),
+		resource: data?.agentCwd || data?.gitContext?.cwd,
+		repoDisplay: data?.repoInfo?.display,
+	};
+}
+
+function normalizePublicBaseUrl(value) {
+	const raw = value || DEFAULT_PUBLIC_URL;
+	const url = new URL(ensureTrailingSlash(raw));
+	url.hash = "";
+	url.search = "";
+	return url.toString();
+}
+
+function hubLocalBaseUrl(env = process.env) {
+	const host = env.PLANNOTATOR_HUB_BIND || DEFAULT_BIND_HOST;
+	const port = env.PLANNOTATOR_HUB_PORT || String(DEFAULT_HUB_PORT);
+	const resolvedHost = host === "0.0.0.0" ? "127.0.0.1" : host;
+	return `http://${resolvedHost}:${port}`;
+}
+
+function buildPublicSessionUrl(publicBaseUrl, sessionId) {
+	return new URL(`s/${encodeURIComponent(sessionId)}/`, normalizePublicBaseUrl(publicBaseUrl)).toString();
+}
+
+function validateBackendUrl(rawUrl, hubPort = DEFAULT_HUB_PORT) {
+	try {
+		const parsed = new URL(rawUrl);
+		if (parsed.protocol !== "http:") {
+			return { ok: false, reason: "backend URL must use http" };
+		}
+		const hostname = parsed.hostname.toLowerCase();
+		if (!new Set(["127.0.0.1", "localhost", "::1"]).has(hostname)) {
+			return { ok: false, reason: "backend URL must point at localhost" };
+		}
+		const port = Number(parsed.port || "80");
+		if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+			return { ok: false, reason: "backend URL port is invalid" };
+		}
+		if (port === hubPort) {
+			return { ok: false, reason: "backend URL points at the hub port" };
+		}
+		return {
+			ok: true,
+			url: `${parsed.protocol}//${parsed.hostname}:${port}`,
+		};
+	} catch (error) {
+		return {
+			ok: false,
+			reason: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+function rewriteHtmlForSession(html, sessionId) {
+	const prefix = `/s/${encodeURIComponent(sessionId)}`;
+	return String(html)
+		.replaceAll('"/api/', `"${prefix}/api/`)
+		.replaceAll("'/api/", `'${prefix}/api/`)
+		.replaceAll("`/api/", `\`${prefix}/api/`)
+		.replaceAll('"/favicon.svg"', `"${prefix}/favicon.svg"`)
+		.replaceAll("'/favicon.svg'", `'${prefix}/favicon.svg'`)
+		.replaceAll("`/favicon.svg`", `\`${prefix}/favicon.svg\``);
+}
+
+function summarizeSession(entry) {
+	return {
+		id: entry.id,
+		backendUrl: entry.backendUrl,
+		kind: entry.kind,
+		mode: entry.mode,
+		title: entry.title,
+		repoDisplay: entry.repoDisplay,
+		resource: entry.resource,
+		sessionId: entry.sessionId,
+		sessionName: entry.sessionName,
+		sessionFile: entry.sessionFile,
+		cwd: entry.cwd,
+		createdAt: entry.createdAt,
+		updatedAt: entry.updatedAt,
+		url: entry.url,
+	};
+}
+
+function newSessionId() {
+	return randomUUID();
+}
+
+module.exports = {
+	DEFAULT_BIND_HOST,
+	DEFAULT_HUB_PORT,
+	DEFAULT_PUBLIC_URL,
+	buildPublicSessionUrl,
+	describePlanPayload,
+	describeReviewPayload,
+	extractPlanTitle,
+	hubLocalBaseUrl,
+	newSessionId,
+	normalizePublicBaseUrl,
+	rewriteHtmlForSession,
+	summarizeSession,
+	truncateLabel,
+	validateBackendUrl,
+};

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -8,6 +8,11 @@
   "defaultProvider": "openai-codex",
   "defaultModel": "gpt-5.5",
   "defaultThinkingLevel": "high",
+  "plannotatorHub": {
+    "publicUrl": "http://127.0.0.1:19432",
+    "port": 19432,
+    "bind": "127.0.0.1"
+  },
   "skills": [
     "../.codex/skills"
   ],
@@ -20,6 +25,7 @@
     }
   ],
   "extensions": [
+    "extensions/plannotator-hub/index.ts",
     "extensions/plannotator-events/index.ts",
     "extensions/codex-native/index.ts",
     "extensions/token-burden/index.ts",


### PR DESCRIPTION
## Summary
- add a Pi-side Plannotator hub that proxies each localhost Plannotator backend through one stable origin
- add the browser shim, hub server, session picker, path rewriting, cleanup helpers, and stream-error hardening needed for that proxy flow
- ship shared localhost Pi defaults and docs, while leaving personal remote tunnels as a user override

## Testing
- bun test pi/agent/extensions/plannotator-events/index.test.ts pi/agent/extensions/plannotator-hub/index.test.ts pi/agent/extensions/vault/index.test.ts
- bun run typecheck
- pre-commit check suite