### PR TITLE
fix(plannotator-hub): avoid double-write crash after proxy errors

### DIFF
--- a/pi/agent/extensions/plannotator-hub/hub-server.cjs
+++ b/pi/agent/extensions/plannotator-hub/hub-server.cjs
@@ -52,6 +52,17 @@ function text(res, status, body, headers = {}) {
 	res.end(body);
 }
 
+function tryText(res, status, body, headers = {}, error) {
+	if (res.headersSent || res.writableEnded) {
+		if (!res.destroyed && typeof res.destroy === "function") {
+			res.destroy(error instanceof Error ? error : undefined);
+		}
+		return false;
+	}
+	text(res, status, body, headers);
+	return true;
+}
+
 function escapeHtml(value) {
 	return String(value || "")
 		.replaceAll("&", "&amp;")
@@ -387,7 +398,7 @@ async function startServer() {
 				} catch (error) {
 					if (error instanceof Error && /(ECONNREFUSED|fetch failed|socket hang up)/i.test(error.message)) {
 						removeSession(state, sessionId);
-						text(res, 404, "<h1>Closed Plannotator session</h1>");
+						tryText(res, 404, "<h1>Closed Plannotator session</h1>", {}, error);
 						return;
 					}
 					throw error;
@@ -398,7 +409,7 @@ async function startServer() {
 			text(res, 404, "<h1>Not found</h1>");
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			text(res, 500, `<h1>Plannotator hub error</h1><pre>${escapeHtml(message)}</pre>`);
+			tryText(res, 500, `<h1>Plannotator hub error</h1><pre>${escapeHtml(message)}</pre>`, {}, error);
 		}
 	});
 
@@ -423,4 +434,5 @@ module.exports = {
 	removeSession,
 	renderHubPage,
 	startServer,
+	tryText,
 };

--- a/pi/agent/extensions/plannotator-hub/index.test.ts
+++ b/pi/agent/extensions/plannotator-hub/index.test.ts
@@ -31,6 +31,20 @@ const hubServer = require("./hub-server.cjs") as {
 		},
 		sessionId: string,
 	) => boolean;
+	tryText: (
+		res: {
+			headersSent?: boolean;
+			writableEnded?: boolean;
+			destroyed?: boolean;
+			destroy?: (error?: Error) => void;
+			writeHead?: (...args: unknown[]) => void;
+			end?: (...args: unknown[]) => void;
+		},
+		status: number,
+		body: string,
+		headers?: Record<string, string>,
+		error?: Error,
+	) => boolean;
 };
 
 describe("plannotator hub environment", () => {
@@ -198,5 +212,25 @@ describe("plannotator hub helpers", () => {
 		expect(hubServer.removeSession(state, "session-a")).toBe(true);
 		expect(state.sessions.size).toBe(0);
 		expect(state.sessionIdsByBackend.size).toBe(0);
+	});
+
+	test("closes an already-started response instead of writing headers again", () => {
+		const error = new Error("socket hang up");
+		const calls: string[] = [];
+		const res = {
+			headersSent: true,
+			writableEnded: false,
+			destroyed: false,
+			writeHead: () => calls.push("writeHead"),
+			end: () => calls.push("end"),
+			destroy: (receivedError?: Error) => {
+				calls.push(receivedError?.message ?? "destroy");
+			},
+		};
+
+		const handled = hubServer.tryText(res, 500, "<h1>boom</h1>", {}, error);
+
+		expect(handled).toBe(false);
+		expect(calls).toEqual(["socket hang up"]);
 	});
 });


### PR DESCRIPTION
## Summary
- avoid crashing the Plannotator hub when a proxied request fails after the response has already started
- close an already-started response instead of attempting to write a second error page
- add regression coverage for the headers-sent path

## Testing
- bun test pi/agent/extensions/plannotator-hub/index.test.ts pi/agent/extensions/plannotator-events/index.test.ts pi/agent/extensions/vault/index.test.ts
- bun run typecheck
- node --check pi/agent/extensions/plannotator-hub/hub-server.cjs