### PR TITLE
feat: improve hub lane binding and review artifact labels

### DIFF
--- a/pi/agent/extensions/mux-sidebar.ts
+++ b/pi/agent/extensions/mux-sidebar.ts
@@ -9,6 +9,7 @@ type MuxPiState = {
 	paneId: string;
 	pid: number;
 	cwd: string;
+	sessionId?: string;
 	sessionFile?: string;
 	sessionName?: string;
 	provider?: string;
@@ -112,6 +113,7 @@ export default function muxSidebarExtension(pi: ExtensionAPI) {
 				paneId: pane,
 				pid: process.pid,
 				cwd: ctx.cwd,
+				sessionId: ctx.sessionManager.getSessionId(),
 				sessionFile: ctx.sessionManager.getSessionFile() ?? undefined,
 				sessionName: sessionName(pi),
 				provider: ctx.model?.provider,

--- a/pi/agent/extensions/plannotator-hub/hub-server.cjs
+++ b/pi/agent/extensions/plannotator-hub/hub-server.cjs
@@ -20,7 +20,38 @@ const {
 } = require("./shared.cjs");
 
 const SESSION_TTL_MS = 12 * 60 * 60 * 1000;
+const LOG_PREFIX = "[plannotator-hub]";
 const SECRET_PATH = process.env.PLANNOTATOR_HUB_SECRET_FILE || join(homedir(), ".pi", "plannotator-hub-secret");
+
+function logLifecycle(message) {
+	try {
+		process.stderr.write(`${new Date().toISOString()} ${LOG_PREFIX} ${message}\n`);
+	} catch {}
+}
+
+process.on("uncaughtException", (error) => {
+	logLifecycle(`uncaughtException: ${error && error.stack ? error.stack : String(error)}`);
+	process.exit(1);
+});
+
+process.on("unhandledRejection", (reason) => {
+	logLifecycle(`unhandledRejection: ${reason && reason.stack ? reason.stack : String(reason)}`);
+	process.exit(1);
+});
+
+process.once("SIGTERM", () => {
+	logLifecycle("received SIGTERM");
+	process.exit(143);
+});
+
+process.once("SIGINT", () => {
+	logLifecycle("received SIGINT");
+	process.exit(130);
+});
+
+process.on("exit", (code) => {
+	logLifecycle(`process exit code=${code}`);
+});
 
 function ensureSecret() {
 	if (existsSync(SECRET_PATH)) {
@@ -415,7 +446,7 @@ async function startServer() {
 
 	server.listen(hubPort, bindHost, () => {
 		const address = state.publicBaseUrl;
-		process.stdout.write(`[plannotator-hub] listening on ${bindHost}:${hubPort} (public ${address})\n`);
+		process.stdout.write(`${LOG_PREFIX} listening on ${bindHost}:${hubPort} (public ${address})\n`);
 	});
 }
 

--- a/pi/agent/extensions/plannotator-hub/index.test.ts
+++ b/pi/agent/extensions/plannotator-hub/index.test.ts
@@ -62,6 +62,7 @@ describe("plannotator hub environment", () => {
 		expect(env.PLANNOTATOR_HUB_SCRIPT).toContain("hub-server.cjs");
 		const shimEnvKey = process.platform === "darwin" ? "BROWSER" : "PLANNOTATOR_BROWSER";
 		expect(env[shimEnvKey]).toContain("browser-shim.cjs");
+		expect(env.PLANNOTATOR_HUB_LOG_FILE).toContain("plannotator-hub.log");
 		expect(env.PLANNOTATOR_HUB_OPEN_BROWSER).toBe("/usr/bin/firefox");
 	});
 
@@ -97,6 +98,7 @@ describe("plannotator hub environment", () => {
 		expect(env.PLANNOTATOR_HUB_PUBLIC_URL).toBe("https://plannotator.noxcraft.dev");
 		expect(env.PLANNOTATOR_HUB_PORT).toBe("19432");
 		expect(env.PLANNOTATOR_HUB_BIND).toBe("127.0.0.1");
+		expect(env.PLANNOTATOR_HUB_LOG_FILE).toContain("plannotator-hub.log");
 	});
 
 	test("settings can disable the hub wiring", () => {

--- a/pi/agent/extensions/plannotator-hub/index.ts
+++ b/pi/agent/extensions/plannotator-hub/index.ts
@@ -1,11 +1,14 @@
 import { spawn } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import { appendFileSync, closeSync, mkdirSync, openSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { SettingsManager } from "@earendil-works/pi-coding-agent";
 
 const DEFAULT_HUB_PORT = "19432";
 const DEFAULT_HUB_BIND = "127.0.0.1";
+const DEFAULT_HUB_LOG_FILE = join(homedir(), ".pi", "plannotator-hub.log");
 const DISABLE_ENV = "PLANNOTATOR_HUB_DISABLED";
 const HUB_START_TIMEOUT_MS = 5_000;
 const missing = Symbol("plannotatorHubMissing");
@@ -33,6 +36,20 @@ export function getPlannotatorHubPaths() {
 function defaultPublicUrl(env: NodeJS.ProcessEnv) {
 	const port = env.PLANNOTATOR_HUB_PORT || DEFAULT_HUB_PORT;
 	return `http://127.0.0.1:${port}`;
+}
+
+function logFilePath(env: NodeJS.ProcessEnv) {
+	return env.PLANNOTATOR_HUB_LOG_FILE || DEFAULT_HUB_LOG_FILE;
+}
+
+function logHubSupervisor(env: NodeJS.ProcessEnv, message: string) {
+	const path = logFilePath(env);
+	try {
+		mkdirSync(dirname(path), { recursive: true });
+		appendFileSync(path, `${new Date().toISOString()} [plannotator-hub-supervisor] ${message}\n`);
+	} catch {
+		// Logging failures must never block hub startup.
+	}
 }
 
 function applyBrowserShim(env: NodeJS.ProcessEnv, browserShimPath: string) {
@@ -124,6 +141,7 @@ export function applyPlannotatorHubEnvironment(options: { env?: NodeJS.ProcessEn
 	env.PLANNOTATOR_HUB_PORT = settings.port ?? env.PLANNOTATOR_HUB_PORT ?? DEFAULT_HUB_PORT;
 	env.PLANNOTATOR_HUB_BIND = settings.bind ?? env.PLANNOTATOR_HUB_BIND ?? DEFAULT_HUB_BIND;
 	env.PLANNOTATOR_HUB_PUBLIC_URL = settings.publicUrl ?? env.PLANNOTATOR_HUB_PUBLIC_URL ?? defaultPublicUrl(env);
+	env.PLANNOTATOR_HUB_LOG_FILE = env.PLANNOTATOR_HUB_LOG_FILE ?? DEFAULT_HUB_LOG_FILE;
 	env.PLANNOTATOR_HUB_SCRIPT ||= hubServerPath;
 
 	// The hub owns the fixed public port. Upstream Plannotator must stay on random loopback ports.
@@ -153,25 +171,55 @@ async function isHubHealthy(env: NodeJS.ProcessEnv = process.env) {
 
 function startHubProcess(env: NodeJS.ProcessEnv = process.env) {
 	const scriptPath = env.PLANNOTATOR_HUB_SCRIPT;
-	if (!scriptPath) return;
+	if (!scriptPath) {
+		logHubSupervisor(env, "skipping spawn because PLANNOTATOR_HUB_SCRIPT is unset");
+		return;
+	}
+	const path = logFilePath(env);
+	mkdirSync(dirname(path), { recursive: true });
+	const stdoutFd = openSync(path, "a");
+	const stderrFd = openSync(path, "a");
+	logHubSupervisor(
+		env,
+		`spawning ${process.execPath} ${scriptPath} on ${localHubBaseUrl(env)} with public ${env.PLANNOTATOR_HUB_PUBLIC_URL || defaultPublicUrl(env)}`,
+	);
 	const child = spawn(process.execPath, [scriptPath], {
 		detached: true,
-		stdio: "ignore",
+		stdio: ["ignore", stdoutFd, stderrFd],
 		env,
 	});
-	child.once("error", () => {});
+	closeSync(stdoutFd);
+	closeSync(stderrFd);
+	logHubSupervisor(env, `spawned pid=${child.pid ?? "unknown"}`);
+	child.once("error", (error) => {
+		logHubSupervisor(env, `spawn error: ${error.message}`);
+	});
+	child.once("exit", (code, signal) => {
+		logHubSupervisor(
+			env,
+			`child exit pid=${child.pid ?? "unknown"} code=${code ?? "null"} signal=${signal ?? "null"}`,
+		);
+	});
 	child.unref();
 }
 
 async function ensurePlannotatorHub(env: NodeJS.ProcessEnv = process.env) {
-	if (await isHubHealthy(env)) return;
+	logHubSupervisor(env, `ensure start for ${localHubBaseUrl(env)}`);
+	if (await isHubHealthy(env)) {
+		logHubSupervisor(env, `health check passed for ${localHubBaseUrl(env)}`);
+		return;
+	}
 
 	startHubProcess(env);
 	const deadline = Date.now() + HUB_START_TIMEOUT_MS;
 	while (Date.now() < deadline) {
 		await new Promise((resolve) => setTimeout(resolve, 250));
-		if (await isHubHealthy(env)) return;
+		if (await isHubHealthy(env)) {
+			logHubSupervisor(env, `hub became healthy for ${localHubBaseUrl(env)}`);
+			return;
+		}
 	}
+	logHubSupervisor(env, `hub failed to become healthy within ${HUB_START_TIMEOUT_MS}ms for ${localHubBaseUrl(env)}`);
 }
 
 function setOrDelete(env: NodeJS.ProcessEnv, key: string, value?: string) {

--- a/pi/agent/extensions/review-artifacts/index.test.ts
+++ b/pi/agent/extensions/review-artifacts/index.test.ts
@@ -25,7 +25,7 @@ describe("review artifact helpers", () => {
 	test("builds html image gallery entries", () => {
 		const html = buildImageReviewHtml("/tmp/screens", ["/tmp/screens/a.png", "/tmp/screens/sub/b.jpg"]);
 		expect(html).toContain("<!doctype html>");
-		expect(html).toContain("<h1>Image review: screens</h1>");
+		expect(html).toContain("<h1>screens</h1>");
 		expect(html).toContain("<h2>a.png</h2>");
 		expect(html).toContain("<h2>sub/b.jpg</h2>");
 		expect(html).toContain('<img alt="a.png" src="./api/image?path=%2Ftmp%2Fscreens%2Fa.png"');
@@ -41,6 +41,7 @@ describe("review artifact helpers", () => {
 		expect(imagePaths).toEqual([join(dir, "a.png"), join(nested, "b.jpg")]);
 		const reviewHtml = readFileSync(reviewPath, "utf-8");
 		expect(reviewPath.endsWith(".html")).toBe(true);
+		expect(reviewPath).toMatch(/\/review-images-[^/]+\/review-images-[^/]+\.html$/);
 		expect(reviewHtml).toContain("Image count");
 		expect(reviewHtml).toContain("<h2>nested/b.jpg</h2>");
 		expect(rawHtml).toContain("<h2>a.png</h2>");
@@ -158,9 +159,10 @@ describe("review artifact extension registration", () => {
 		expect(calls).toHaveLength(2);
 		expect(calls[0][1]).toBe(htmlPath);
 		expect(calls[0][8]).toContain("<h1>Mock</h1>");
-		expect(calls[1][1]).toEndWith(".html");
+		expect(calls[1][1]).toContain("/mock-screenshots.html");
 		expect(calls[1][8]).toContain("desktop.png");
 		expect(calls[1][8]).toContain("mobile.png");
+		expect(calls[1][8]).toContain("<h1>mock.html screenshots</h1>");
 		expect(calls[1][9]).toBe(true);
 	});
 

--- a/pi/agent/extensions/review-artifacts/index.ts
+++ b/pi/agent/extensions/review-artifacts/index.ts
@@ -126,6 +126,26 @@ function escapeHtml(value: string): string {
 	return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
 }
 
+function fileStem(path: string): string {
+	const ext = extname(path);
+	return ext ? basename(path, ext) : basename(path);
+}
+
+function sanitizeArtifactName(value: string): string {
+	const trimmed = value.trim().toLowerCase();
+	const collapsed = trimmed
+		.replace(/[^a-z0-9._-]+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-|-$/g, "");
+	return collapsed || "review";
+}
+
+function createReviewArtifactPath(label: string): string {
+	const dir = join(REVIEW_ARTIFACT_DIR, `${sanitizeArtifactName(label)}-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return join(dir, `${sanitizeArtifactName(label)}.html`);
+}
+
 export function buildImageReviewHtml(
 	targetPath: string,
 	imagePaths: string[],
@@ -136,7 +156,7 @@ export function buildImageReviewHtml(
 ): string {
 	const singleImage = imagePaths.length === 1 && IMAGE_EXTENSIONS.has(extname(targetPath).toLowerCase());
 	const rootPath = singleImage ? dirname(targetPath) : targetPath;
-	const title = options?.title ?? `Image review: ${basename(targetPath)}`;
+	const title = options?.title ?? basename(targetPath);
 	const intro =
 		options?.intro ??
 		"Review the image set below. Use annotations to point out visual regressions, layout issues, or naming mistakes.";
@@ -199,6 +219,7 @@ export function createImageReviewArtifact(
 	options?: {
 		title?: string;
 		intro?: string;
+		artifactName?: string;
 	},
 ): {
 	reviewPath: string;
@@ -221,9 +242,8 @@ export function createImageReviewArtifact(
 		throw new Error(`Image review expects an image file or folder, got: ${targetPath}`);
 	}
 
-	mkdirSync(REVIEW_ARTIFACT_DIR, { recursive: true });
 	const rawHtml = buildImageReviewHtml(targetPath, imagePaths, options);
-	const reviewPath = join(REVIEW_ARTIFACT_DIR, `${basename(targetPath) || "images"}-${randomUUID()}.html`);
+	const reviewPath = createReviewArtifactPath(options?.artifactName ?? basename(targetPath) ?? "images");
 	writeFileSync(reviewPath, rawHtml, "utf-8");
 	return { reviewPath, rawHtml, imagePaths };
 }
@@ -346,8 +366,9 @@ async function openHtmlScreenshotReview(
 	ctx.ui.notify(`Capturing screenshots for ${resolvedPath}...`, "info");
 	const { screenshotDir, screenshotPaths } = await captureHtmlScreenshots(pi, resolvedPath);
 	const screenshotReview = createImageReviewArtifact(screenshotDir, {
-		title: `HTML screenshot review: ${basename(resolvedPath)}`,
+		title: `${basename(resolvedPath)} screenshots`,
 		intro: `Review screenshots captured from ${resolvedPath}. Use annotations to call out rendering, layout, and responsiveness issues.`,
+		artifactName: `${fileStem(resolvedPath)}-screenshots`,
 	});
 	ctx.ui.notify(`Opening screenshot review for ${resolvedPath}...`, "info");
 	const result = await openAnnotationReview(ctx, {


### PR DESCRIPTION
## Summary
- publish Pi session ids from mux-sidebar for stronger Majin lane binding
- harden Plannotator hub startup and proxy error handling with supervisor logging
- generate friendly HTML/image review artifact names and screenshot review titles

## Testing
- full pre-commit suite via hooks
